### PR TITLE
Escape Backslashes in output

### DIFF
--- a/teams-notifications-command.conf
+++ b/teams-notifications-command.conf
@@ -121,7 +121,7 @@ object NotificationCommand "teams-notifications-command" {
 	    var state_duration = "{\"name\":\"Duration\",\"value\":\"" + host_duration_readable + "\"},"
         }
     }
-	plugin_output_escaped = plugin_output.replace("\"", "\\\"")
+	plugin_output_escaped = plugin_output.replace("\"", "\\\"").replace("\\", "\\\\")
     payload_attachments = "{\"@type\":\"MessageCard\",\"themeColor\":\"" + color + "\",\"summary\":\"" + fallback_text + "\",\"sections\":[{\"activityTitle\":\"" + fallback_text + "\",\"facts\":[{\"name\":\"Host\",\"value\":\"" + host_name_with_link + "\"}," + service_details + "{\"name\":\"State\",\"value\":\"" + state_text + "\"}," + state_duration + notification_type_custom_text + "{\"name\":\"Plugin output\",\"value\":\"```" + plugin_output_escaped + "```\"}],\"markdown\":true}]}"
 
     log(LogDebug, "teams-notifications", "Sending notification...generated notification text successfully: " + payload_attachments)


### PR DESCRIPTION
E.g. the check_disk has a Backslash in the service_output that provokes an curl error otherwise, because the json payload is not valid.